### PR TITLE
Update matching.py

### DIFF
--- a/pql/matching.py
+++ b/pql/matching.py
@@ -376,12 +376,10 @@ class IntField(AlgebricField):
     def handle_Num(self, node):
         return node.n
     def handle_UnaryOp(self, node):
-        op_type = type(node.op)
-        if (op_type == ast.USub):
-            return - node.operand.value
-        else:
-            return node.operand.value
-
+        op_map = {ast.USub: '-', ast.UAdd: '+'}
+        op_class = node.op.__class__
+        if op_class in op_map:
+            return ast.literal_eval(f'{op_map.get(op_class, "")}{node.operand.value}')
     def handle_Call(self, node):
         return IntFunc().handle(node)
 


### PR DESCRIPTION
https://github.com/comfuture/pql/pull/1#discussion_r444872708

제안해주신 코드를 보고 ast.literal_eval을 사용해봤는데 +를 적절하게 없애주는 것을 확인했습니다
동작은 같겠지만
https://github.com/comfuture/pql/blob/master/pql/matching.py#L381
같이 `-` 연산자를 그냥 넣어둔 것보다 좋은 것 같습니다
